### PR TITLE
omit empty example

### DIFF
--- a/golang/omitempty-nil/go.mod
+++ b/golang/omitempty-nil/go.mod
@@ -1,0 +1,3 @@
+module github.com/perebaj/playground/golang/omitemptynil
+
+go 1.23.5

--- a/golang/omitempty-nil/main_test.go
+++ b/golang/omitempty-nil/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+type User struct {
+	Name *string `json:"name"`
+	Age  int     `json:"age,omitempty"`
+}
+
+func TestUser(t *testing.T) {
+	user := User{
+		Name: nil,
+		Age:  0,
+	}
+
+	b, err := json.Marshal(user)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(b) != `{"name":null}` {
+		t.Errorf("expected %s, got %s", `{"name":null}`, string(b))
+	}
+}
+
+func TestUserWithOmitEmpty(t *testing.T) {
+	type UserWithOmitEmpty struct {
+		Name *string `json:"name,omitempty"`
+		Age  int     `json:"age,omitempty"`
+	}
+
+	user := UserWithOmitEmpty{
+		Name: nil,
+		Age:  0,
+	}
+
+	b, err := json.Marshal(user)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(b) != `{}` {
+		t.Errorf("expected %s, got %s", `{}`, string(b))
+	}
+}


### PR DESCRIPTION
Without omitempty on pointer field, eehen Name is nil, it will be included in the JSON as null.

With omitempty on pointer field, ehen Name is nil, the field will be completely omitted from the JSON

More: https://www.infoq.com/presentations/Null-References-The-Billion-Dollar-Mistake-Tony-Hoare/


