### PR TITLE
reproduction batch 400 err

### DIFF
--- a/repro-batch-400/README.md
+++ b/repro-batch-400/README.md
@@ -6,6 +6,14 @@ Reproduces 400 errors caused by a partner's OTel Collector config that batches 1
 
 The `batch/logs_export` processor with `send_batch_size: 100000` creates OTLP HTTP requests too large for raincatcher to accept, resulting in HTTP 400 (InvalidArgument).
 
+The serialized protobuf payload exceeds the NATS limits in the pipeline:
+
+| Limit | Dev | Prod |
+|-------|-----|------|
+| NATS `max_payload` | 1 MB | 8 MB |
+| `og-logs` stream `max_msg_size` | 1 MiB | 2 MiB |
+| gRPC max recv (raincatcher) | 4 MB | 4 MB |
+
 ## Setup
 
 ```bash
@@ -13,7 +21,7 @@ cd repro-batch-400
 export OLLY_GARDEN_API_KEY="og_sk_..."
 ```
 
-## Test 1: Large batch (100K) — should reproduce the 400 errors
+## Test 1: Large batch (100K) — reproduce the 400 errors
 
 ```bash
 docker compose -f docker-compose-large-batch.yml up
@@ -49,18 +57,108 @@ Stop:
 docker compose -f docker-compose-small-batch.yml down
 ```
 
+## Test 3: Measure payload sizes and compression (no prod traffic)
+
+Sends batches to a local HTTP server that logs wire size, decompressed size, compression ratio, and decompression time. No data is sent to production.
+
+Generates **realistic multi-service traffic** with all three signal types:
+- **Logs**: 3 services (api-gateway, order-processor, auth-service) with varied bodies, severity levels, and attributes
+- **Traces**: 2 services (api-gateway, payment-service) with different span durations and status codes
+- **Metrics**: 1 service (infra-monitor) with Kubernetes attributes
+
+Tests 4 compression formats side by side:
+- `none` — raw protobuf (what raincatcher publishes to NATS today)
+- `snappy` — proposed for raincatcher→NATS (E-1029)
+- `zstd` — used by STEF dual-publish
+- `gzip` — default OTel HTTP transport compression
+
+### Large batch (100K)
+
+```bash
+docker compose -f docker-compose-large-batch-sizer.yml up
+docker logs -f payload-sizer-large
+```
+
+### Small batch (5K)
+
+```bash
+docker compose -f docker-compose-small-batch-sizer.yml up
+docker logs -f payload-sizer-small
+```
+
+### Example output
+
+```
+[  none] [   logs] wire:   27,100,000 bytes ( 25.84 MB) | decompressed:   27,100,000 bytes ( 25.84 MB) | ratio:   1.0x | decompress: N/A
+[snappy] [   logs] wire:    1,928,682 bytes (  1.84 MB) | decompressed:   27,100,000 bytes ( 25.84 MB) | ratio:  14.1x | decompress: 1234us
+[  zstd] [   logs] wire:      396,527 bytes (  0.38 MB) | decompressed:   27,100,000 bytes ( 25.84 MB) | ratio:  68.3x | decompress: 567us
+[  gzip] [   logs] wire:      543,860 bytes (  0.52 MB) | decompressed:   27,100,000 bytes ( 25.84 MB) | ratio:  49.8x | decompress: 890us
+[  none] [ traces] wire:    ...
+[snappy] [ traces] wire:    ...
+[  none] [metrics] wire:    ...
+```
+
+### How to interpret
+
+The **decompressed size** = raw protobuf = what raincatcher publishes to NATS today.
+The **wire size per format** = what the NATS message size would be if raincatcher compressed before publishing.
+
+Compare against pipeline limits:
+
+| Limit | Value |
+|-------|-------|
+| NATS `max_payload` (dev) | 1 MB |
+| NATS `max_payload` (prod) | 8 MB |
+| `og-logs` `max_msg_size` (prod) | 2 MiB |
+| `og-traces` `max_msg_size` (prod) | 10 MiB |
+| `og-metrics` `max_msg_size` (prod) | 8 MiB |
+
+## Results (100K batch, realistic multi-service traffic)
+
+Tested with multiple telemetrygen services producing diverse resource attributes, log bodies, span types, and metric types.
+
+### Payload sizes per signal and compression format
+
+| Signal | Raw protobuf | Snappy | Zstd | Gzip |
+|--------|-------------|--------|------|------|
+| **Logs** | 57.63 MB | 4.36 MB (13.2x) | 0.63 MB (91.5x) | 0.91 MB (63.4x) |
+| **Traces** | 27.34 MB | 4.04 MB (6.8x) | 2.55 MB (10.7x) | 2.73 MB (10.0x) |
+| **Metrics** | 40.05 MB | 3.10 MB (12.9x) | 0.77 MB (52.0x) | 1.02 MB (39.4x) |
+
+### Decompression time (Python/cramjam, indicative only)
+
+| Signal | Snappy | Zstd | Gzip |
+|--------|--------|------|------|
+| **Logs** | 25-44 ms | 22-44 ms | 18-21 ms |
+| **Traces** | 15 ms | 17 ms | 29 ms |
+| **Metrics** | 6-19 ms | 14-46 ms | 15-25 ms |
+
+> Note: These are Python decompression times, not Go. Go's snappy/zstd implementations are significantly faster (typically 5-10x). These numbers are useful for relative comparison between formats, not absolute performance.
+
+### Would compression fit within NATS limits?
+
+| Signal | Raw protobuf | Snappy compressed | vs prod `max_payload` (8 MB) | vs prod stream `max_msg_size` |
+|--------|-------------|-------------------|-----------------------------|-----------------------------|
+| **Logs** | 57.63 MB | **4.36 MB** | OK | **over** (og-logs: 2 MiB) |
+| **Traces** | 27.34 MB | **4.04 MB** | OK | OK (og-traces: 10 MiB) |
+| **Metrics** | 40.05 MB | **3.10 MB** | OK | OK (og-metrics: 8 MiB) |
+
+### Key findings
+
+1. **Snappy compression makes 100K batches fit within NATS `max_payload` (8 MB)** for all signal types
+2. **Logs still exceed `og-logs` stream limit** (2 MiB) even with Snappy — the stream limit must be raised or batch size reduced
+3. **Traces compress the least** (6.8x vs 13.2x for logs) because trace IDs and span IDs are high-entropy random bytes
+4. **Zstd achieves the best ratios** (10-91x) but is slower; Snappy is the best CPU/compression tradeoff
+5. **Without compression**, a 100K batch produces 27-58 MB of raw protobuf — 3.5-7x over the 8 MB `max_payload`
+
 ## Configs
 
-| File | Batch Size | Expected Result |
-|------|-----------|-----------------|
-| `otel-collector-config-large-batch.yaml` | 100,000 (double batch) | 400 errors |
-| `otel-collector-config-small-batch.yaml` | 5,000 (single batch) | Success |
-
-## What the log generator does
-
-- 10 workers sending 5,000 logs/sec each = ~50K logs/sec total
-- Runs for 120 seconds
-- The collector batches these and exports as HTTP POST to `https://in.ollygarden.cloud/v1/logs`
+| File | Batch Size | Target | Purpose |
+|------|-----------|--------|---------|
+| `otel-collector-config-large-batch.yaml` | 100,000 | Production | Reproduce 400 errors |
+| `otel-collector-config-small-batch.yaml` | 5,000 | Production | Verify fix |
+| `otel-collector-config-large-batch-sizer.yaml` | 100,000 | Local sizer | Measure payload sizes (all signals, all compression) |
+| `otel-collector-config-small-batch-sizer.yaml` | 5,000 | Local sizer | Measure payload sizes (all signals, all compression) |
 
 ## Collector version
 
@@ -71,4 +169,6 @@ Uses `0.131.0` to match the partner's version (`service.version: "0.131.0-dev"` 
 ```bash
 docker compose -f docker-compose-large-batch.yml down -v
 docker compose -f docker-compose-small-batch.yml down -v
+docker compose -f docker-compose-large-batch-sizer.yml down -v
+docker compose -f docker-compose-small-batch-sizer.yml down -v
 ```

--- a/repro-batch-400/README.md
+++ b/repro-batch-400/README.md
@@ -1,0 +1,74 @@
+# Batch Size 400 Error Reproduction
+
+Reproduces 400 errors caused by a partner's OTel Collector config that batches 100K log records into a single HTTP export request.
+
+## Hypothesis
+
+The `batch/logs_export` processor with `send_batch_size: 100000` creates OTLP HTTP requests too large for raincatcher to accept, resulting in HTTP 400 (InvalidArgument).
+
+## Setup
+
+```bash
+cd repro-batch-400
+export OLLY_GARDEN_API_KEY="og_sk_..."
+```
+
+## Test 1: Large batch (100K) — should reproduce the 400 errors
+
+```bash
+docker compose -f docker-compose-large-batch.yml up
+```
+
+Watch for errors:
+
+```bash
+docker logs -f otel-collector-large-batch 2>&1 | grep -iE "400|error|drop"
+```
+
+Stop:
+
+```bash
+docker compose -f docker-compose-large-batch.yml down
+```
+
+## Test 2: Small batch (5K) — should succeed
+
+```bash
+docker compose -f docker-compose-small-batch.yml up
+```
+
+Watch for errors:
+
+```bash
+docker logs -f otel-collector-small-batch 2>&1 | grep -iE "400|error|drop"
+```
+
+Stop:
+
+```bash
+docker compose -f docker-compose-small-batch.yml down
+```
+
+## Configs
+
+| File | Batch Size | Expected Result |
+|------|-----------|-----------------|
+| `otel-collector-config-large-batch.yaml` | 100,000 (double batch) | 400 errors |
+| `otel-collector-config-small-batch.yaml` | 5,000 (single batch) | Success |
+
+## What the log generator does
+
+- 10 workers sending 5,000 logs/sec each = ~50K logs/sec total
+- Runs for 120 seconds
+- The collector batches these and exports as HTTP POST to `https://in.ollygarden.cloud/v1/logs`
+
+## Collector version
+
+Uses `0.131.0` to match the partner's version (`service.version: "0.131.0-dev"` from their error logs).
+
+## Cleanup
+
+```bash
+docker compose -f docker-compose-large-batch.yml down -v
+docker compose -f docker-compose-small-batch.yml down -v
+```

--- a/repro-batch-400/compression-bench/Dockerfile
+++ b/repro-batch-400/compression-bench/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.24-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY main.go .
+RUN CGO_ENABLED=0 go build -o compression-bench .
+
+FROM alpine:3.20
+COPY --from=builder /app/compression-bench /usr/local/bin/compression-bench
+ENTRYPOINT ["compression-bench"]

--- a/repro-batch-400/compression-bench/go.mod
+++ b/repro-batch-400/compression-bench/go.mod
@@ -1,0 +1,5 @@
+module compression-bench
+
+go 1.25.0
+
+require github.com/klauspost/compress v1.18.4

--- a/repro-batch-400/compression-bench/go.sum
+++ b/repro-batch-400/compression-bench/go.sum
@@ -1,0 +1,2 @@
+github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
+github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=

--- a/repro-batch-400/compression-bench/main.go
+++ b/repro-batch-400/compression-bench/main.go
@@ -1,0 +1,222 @@
+// compression-bench is a small OTLP HTTP receiver that measures decompression
+// performance of snappy, zstd, and gzip on real protobuf payloads.
+//
+// It listens on /v1/logs, /v1/traces, and /v1/metrics, decompresses whatever
+// the sender used, then re-compresses + re-decompresses with all three codecs
+// to produce a side-by-side comparison.
+//
+// Usage:
+//
+//	go run main.go [-port :4318]
+package main
+
+import (
+	"bytes"
+	"compress/gzip"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/klauspost/compress/snappy"
+	"github.com/klauspost/compress/zstd"
+)
+
+// zstd encoder/decoder are reused across requests — they are goroutine-safe
+// when constructed with default options.
+var (
+	zstdEncoder *zstd.Encoder
+	zstdDecoder *zstd.Decoder
+)
+
+func init() {
+	var err error
+	zstdEncoder, err = zstd.NewWriter(nil)
+	if err != nil {
+		log.Fatalf("creating zstd encoder: %v", err)
+	}
+	zstdDecoder, err = zstd.NewReader(nil)
+	if err != nil {
+		log.Fatalf("creating zstd decoder: %v", err)
+	}
+}
+
+func main() {
+	port := flag.String("port", ":4318", "listen address (e.g. :4318)")
+	flag.Parse()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/logs", makeHandler("logs"))
+	mux.HandleFunc("/v1/traces", makeHandler("traces"))
+	mux.HandleFunc("/v1/metrics", makeHandler("metrics"))
+
+	log.Printf("compression-bench listening on %s", *port)
+	if err := http.ListenAndServe(*port, mux); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}
+
+func makeHandler(signal string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		compressed, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("reading body: %v", err), http.StatusBadRequest)
+			return
+		}
+		defer r.Body.Close()
+
+		encoding := r.Header.Get("Content-Encoding")
+
+		// Decompress the original payload, measuring only decompression time.
+		decompressStart := time.Now()
+		raw, err := decompress(encoding, compressed)
+		decompressElapsed := time.Since(decompressStart)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("decompressing %s body: %v", encoding, err), http.StatusBadRequest)
+			return
+		}
+
+		rawSize := float64(len(raw)) / (1024 * 1024)
+
+		// Benchmark all three codecs: compress then decompress.
+		snappyResult := benchCodec("snappy", raw)
+		zstdResult := benchCodec("zstd", raw)
+		gzipResult := benchCodec("gzip", raw)
+
+		// Print the summary. If there was no encoding on the wire, the
+		// decompressElapsed is essentially zero (just a copy); we still print it
+		// for consistency.
+		fmt.Printf(
+			"[%s] raw: %.2f MB | snappy: %.2f MB (%.1fx, compress: %dms, decompress: %dms) | zstd: %.2f MB (%.1fx, compress: %dms, decompress: %dms) | gzip: %.2f MB (%.1fx, compress: %dms, decompress: %dms) | wire encoding: %s decompress: %dms\n",
+			signal,
+			rawSize,
+			snappyResult.compressedMB, rawSize/snappyResult.compressedMB,
+			snappyResult.compressMs, snappyResult.decompressMs,
+			zstdResult.compressedMB, rawSize/zstdResult.compressedMB,
+			zstdResult.compressMs, zstdResult.decompressMs,
+			gzipResult.compressedMB, rawSize/gzipResult.compressedMB,
+			gzipResult.compressMs, gzipResult.decompressMs,
+			encodingLabel(encoding), decompressElapsed.Milliseconds(),
+		)
+
+		// Respond with 200 OK and an empty protobuf response body. The OTel
+		// Collector expects a valid ExportXxxServiceResponse; an empty body with
+		// 200 is sufficient to satisfy most exporters.
+		w.Header().Set("Content-Type", "application/x-protobuf")
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+type codecResult struct {
+	compressedMB float64
+	compressMs   int64
+	decompressMs int64
+}
+
+func benchCodec(codec string, raw []byte) codecResult {
+	// Compress.
+	compressStart := time.Now()
+	compressed, err := compress(codec, raw)
+	compressElapsed := time.Since(compressStart)
+	if err != nil {
+		log.Printf("compress %s error: %v", codec, err)
+		return codecResult{}
+	}
+
+	// Decompress — we discard the result; we only care about timing.
+	decompressStart := time.Now()
+	_, err = decompress(codec, compressed)
+	decompressElapsed := time.Since(decompressStart)
+	if err != nil {
+		log.Printf("decompress %s error: %v", codec, err)
+		return codecResult{}
+	}
+
+	return codecResult{
+		compressedMB: float64(len(compressed)) / (1024 * 1024),
+		compressMs:   compressElapsed.Milliseconds(),
+		decompressMs: decompressElapsed.Milliseconds(),
+	}
+}
+
+// compress encodes src with the named codec and returns the compressed bytes.
+func compress(codec string, src []byte) ([]byte, error) {
+	switch codec {
+	case "snappy":
+		// Block format — matches what the OTel Collector sends when
+		// compression: snappy is set on the otlphttp exporter.
+		return snappy.Encode(nil, src), nil
+
+	case "zstd":
+		return zstdEncoder.EncodeAll(src, nil), nil
+
+	case "gzip":
+		var buf bytes.Buffer
+		w := gzip.NewWriter(&buf)
+		if _, err := w.Write(src); err != nil {
+			return nil, fmt.Errorf("gzip write: %w", err)
+		}
+		if err := w.Close(); err != nil {
+			return nil, fmt.Errorf("gzip close: %w", err)
+		}
+		return buf.Bytes(), nil
+
+	default:
+		return nil, fmt.Errorf("unknown codec %q", codec)
+	}
+}
+
+// decompress decodes src using the named encoding. An empty or "identity"
+// encoding returns src unchanged.
+func decompress(encoding string, src []byte) ([]byte, error) {
+	switch encoding {
+	case "snappy":
+		out, err := snappy.Decode(nil, src)
+		if err != nil {
+			return nil, fmt.Errorf("snappy decode: %w", err)
+		}
+		return out, nil
+
+	case "zstd":
+		out, err := zstdDecoder.DecodeAll(src, nil)
+		if err != nil {
+			return nil, fmt.Errorf("zstd decode: %w", err)
+		}
+		return out, nil
+
+	case "gzip":
+		r, err := gzip.NewReader(bytes.NewReader(src))
+		if err != nil {
+			return nil, fmt.Errorf("gzip reader: %w", err)
+		}
+		defer r.Close()
+		out, err := io.ReadAll(r)
+		if err != nil {
+			return nil, fmt.Errorf("gzip read: %w", err)
+		}
+		return out, nil
+
+	case "", "identity":
+		// No compression; return a copy so callers can mutate freely.
+		out := make([]byte, len(src))
+		copy(out, src)
+		return out, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported Content-Encoding %q", encoding)
+	}
+}
+
+func encodingLabel(enc string) string {
+	if enc == "" {
+		return "none"
+	}
+	return enc
+}

--- a/repro-batch-400/debug-requests.sh
+++ b/repro-batch-400/debug-requests.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API_KEY="${OLLY_GARDEN_API_KEY:?ERROR: OLLY_GARDEN_API_KEY is not set}"
+ENDPOINT="https://in.ollygarden.cloud/v1/logs"
+
+echo "============================================"
+echo " Test 1: Minimal valid OTLP log request"
+echo " Expects: 200 OK"
+echo "============================================"
+echo ""
+
+curl -sv -X POST "$ENDPOINT" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"batch-debug-test"}}]},"scopeLogs":[{"scope":{"name":"test"},"logRecords":[{"timeUnixNano":"1710000000000000000","body":{"stringValue":"hello from debug test"},"severityText":"INFO"}]}]}]}' \
+  2>&1
+
+echo ""
+echo ""
+echo "============================================"
+echo " Test 2: Large payload (~1MB of log records)"
+echo " Tests server body size limit"
+echo "============================================"
+echo ""
+
+# Generate a ~1MB JSON payload with many log records
+python3 -c "
+import json
+records = []
+for i in range(5000):
+    records.append({
+        'timeUnixNano': '1710000000000000000',
+        'body': {'stringValue': f'large batch test log entry {i} with padding to increase size ' + 'x' * 100},
+        'severityText': 'INFO'
+    })
+payload = {'resourceLogs': [{'resource': {'attributes': [{'key': 'service.name', 'value': {'stringValue': 'batch-debug-test'}}]}, 'scopeLogs': [{'scope': {'name': 'test'}, 'logRecords': records}]}]}
+print(json.dumps(payload))
+" > /tmp/large-batch-payload.json
+
+PAYLOAD_SIZE=$(wc -c < /tmp/large-batch-payload.json | tr -d ' ')
+echo "Payload size: ${PAYLOAD_SIZE} bytes"
+echo ""
+
+curl -sv -X POST "$ENDPOINT" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/large-batch-payload.json \
+  2>&1
+
+echo ""
+echo ""
+echo "============================================"
+echo " Test 3: Very large payload (~5MB)"
+echo " Likely to trigger 400 or 413"
+echo "============================================"
+echo ""
+
+python3 -c "
+import json
+records = []
+for i in range(25000):
+    records.append({
+        'timeUnixNano': '1710000000000000000',
+        'body': {'stringValue': f'very large batch test log entry {i} with extra padding ' + 'x' * 100},
+        'severityText': 'INFO'
+    })
+payload = {'resourceLogs': [{'resource': {'attributes': [{'key': 'service.name', 'value': {'stringValue': 'batch-debug-test'}}]}, 'scopeLogs': [{'scope': {'name': 'test'}, 'logRecords': records}]}]}
+print(json.dumps(payload))
+" > /tmp/very-large-batch-payload.json
+
+PAYLOAD_SIZE=$(wc -c < /tmp/very-large-batch-payload.json | tr -d ' ')
+echo "Payload size: ${PAYLOAD_SIZE} bytes"
+echo ""
+
+curl -sv -X POST "$ENDPOINT" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/very-large-batch-payload.json \
+  2>&1
+
+echo ""
+echo ""
+echo "============================================"
+echo " Test 4: Empty body"
+echo " Checks how server handles invalid input"
+echo "============================================"
+echo ""
+
+curl -sv -X POST "$ENDPOINT" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '' \
+  2>&1
+
+echo ""
+echo ""
+echo "============================================"
+echo " Done. Check the response headers above:"
+echo "  - 'Server: nginx' = nginx rejected it"
+echo "  - gRPC/app error  = raincatcher rejected it"
+echo "  - Look for 'content-length' limits"
+echo "============================================"
+
+rm -f /tmp/large-batch-payload.json /tmp/very-large-batch-payload.json

--- a/repro-batch-400/docker-compose-go-bench.yml
+++ b/repro-batch-400/docker-compose-go-bench.yml
@@ -1,0 +1,131 @@
+services:
+  compression-bench:
+    build: ./compression-bench
+    container_name: compression-bench
+    command: ["-port", ":4318"]
+    networks:
+      - repro-net
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.131.0
+    container_name: otel-collector-go-bench
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config-go-bench.yaml:/etc/otel-collector-config.yaml:ro
+    ports:
+      - "4317:4317"
+    depends_on:
+      - compression-bench
+    networks:
+      - repro-net
+
+  # --- LOG GENERATORS (realistic multi-service) ---
+
+  log-gen-api:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: log-gen-api-bench
+    command:
+      - logs
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=3
+      - --rate=3000
+      - --duration=60s
+      - --severity-text=INFO
+      - --body="[api-gateway] POST /api/v2/orders request_id=a]bf9c2e1 user_id=usr_8x7k2m status=200 latency_ms=142 region=eu-west-1 pod=api-gw-5d8f9-xk2m4"
+      - --telemetry-attributes=service.name="api-gateway",service.version="2.14.3",deployment.environment="production",host.name="api-gw-5d8f9-xk2m4",cloud.region="eu-west-1",cloud.provider="gcp"
+      - --otlp-attributes=http.method="POST",http.route="/api/v2/orders",http.status_code="200",user.tier="enterprise",request.size_bytes="4521",response.size_bytes="892"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  log-gen-worker:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: log-gen-worker-bench
+    command:
+      - logs
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=3
+      - --rate=3000
+      - --duration=60s
+      - --severity-text=WARN
+      - --body="[order-processor] Processing order ord_9f2x8k for customer cust_m3k9x2 items=14 total=EUR_2847.50 warehouse=Frankfurt retry_count=2 queue_depth=847"
+      - --telemetry-attributes=service.name="order-processor",service.version="1.8.0",deployment.environment="production",host.name="worker-7c4b2-p9x1",cloud.region="eu-west-4",cloud.provider="gcp"
+      - --otlp-attributes=order.id="ord_9f2x8k",customer.id="cust_m3k9x2",queue.name="orders-high-priority",processing.stage="validation",db.system="postgresql"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  log-gen-auth:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: log-gen-auth-bench
+    command:
+      - logs
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=2
+      - --rate=2000
+      - --duration=60s
+      - --severity-text=ERROR
+      - --body="[auth-service] Authentication failed for user usr_x9k2m token_type=bearer error=token_expired issuer=https://auth.example.com/oauth2 client_ip=198.51.100.42 user_agent=Mozilla/5.0"
+      - --telemetry-attributes=service.name="auth-service",service.version="3.2.1",deployment.environment="production",host.name="auth-8f7d3-m2x9",cloud.region="eu-west-4",cloud.provider="gcp"
+      - --otlp-attributes=auth.method="oauth2",auth.error="token_expired",net.peer.ip="198.51.100.42",http.user_agent="Mozilla/5.0 (X11; Linux x86_64)",enduser.scope="openid profile email"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  # --- TRACE GENERATORS ---
+
+  trace-gen-api:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: trace-gen-api-bench
+    command:
+      - traces
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=3
+      - --rate=2000
+      - --duration=60s
+      - --span-duration=150ms
+      - --status-code=Ok
+      - --telemetry-attributes=service.name="api-gateway",service.version="2.14.3",deployment.environment="production",host.name="api-gw-5d8f9-xk2m4",cloud.region="eu-west-1"
+      - --otlp-attributes=http.method="GET",http.route="/api/v2/users/:id",http.status_code="200",db.system="postgresql",db.statement="SELECT * FROM users WHERE id = $1",net.peer.name="db-primary.internal"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  trace-gen-worker:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: trace-gen-worker-bench
+    command:
+      - traces
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=3
+      - --rate=2000
+      - --duration=60s
+      - --span-duration=500ms
+      - --status-code=Error
+      - --telemetry-attributes=service.name="payment-service",service.version="4.1.0",deployment.environment="production",host.name="pay-2c9f1-k8x3",cloud.region="eu-west-4"
+      - --otlp-attributes=rpc.system="grpc",rpc.service="PaymentService",rpc.method="ProcessPayment",payment.provider="stripe",payment.currency="EUR",net.peer.name="stripe-api.internal"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  # --- METRIC GENERATORS ---
+
+  metric-gen:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: metric-gen-bench
+    command:
+      - metrics
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=5
+      - --rate=5000
+      - --duration=60s
+      - --metric-type=Sum
+      - --telemetry-attributes=service.name="infra-monitor",service.version="1.0.0",deployment.environment="production",host.name="monitor-4a8c2-j7x9",cloud.region="eu-west-4"
+      - --otlp-attributes=container.name="api-gateway",k8s.pod.name="api-gw-5d8f9-xk2m4",k8s.namespace.name="production",k8s.node.name="gke-prod-pool-1-abc123"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+networks:
+  repro-net:
+    driver: bridge

--- a/repro-batch-400/docker-compose-large-batch-sizer.yml
+++ b/repro-batch-400/docker-compose-large-batch-sizer.yml
@@ -1,0 +1,135 @@
+services:
+  payload-sizer:
+    image: python:3.12-slim
+    container_name: payload-sizer-large
+    volumes:
+      - ./payload-sizer.py:/app/payload-sizer.py:ro
+    command: ["sh", "-c", "pip install --quiet cramjam && python3 /app/payload-sizer.py"]
+    networks:
+      - repro-net
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.131.0
+    container_name: otel-collector-large-batch-sizer
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config-large-batch-sizer.yaml:/etc/otel-collector-config.yaml:ro
+    ports:
+      - "4317:4317"
+    depends_on:
+      - payload-sizer
+    networks:
+      - repro-net
+
+  # --- LOG GENERATORS ---
+  # Multiple workers with different service identities to simulate realistic multi-service traffic.
+  # Each has unique resource attributes so records aren't all identical.
+
+  log-gen-api:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: log-gen-api
+    command:
+      - logs
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=3
+      - --rate=3000
+      - --duration=60s
+      - --severity-text=INFO
+      - --body="[api-gateway] POST /api/v2/orders request_id=a]bf9c2e1 user_id=usr_8x7k2m status=200 latency_ms=142 region=eu-west-1 pod=api-gw-5d8f9-xk2m4"
+      - --telemetry-attributes=service.name="api-gateway",service.version="2.14.3",deployment.environment="production",host.name="api-gw-5d8f9-xk2m4",cloud.region="eu-west-1",cloud.provider="gcp"
+      - --otlp-attributes=http.method="POST",http.route="/api/v2/orders",http.status_code="200",user.tier="enterprise",request.size_bytes="4521",response.size_bytes="892"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  log-gen-worker:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: log-gen-worker
+    command:
+      - logs
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=3
+      - --rate=3000
+      - --duration=60s
+      - --severity-text=WARN
+      - --body="[order-processor] Processing order ord_9f2x8k for customer cust_m3k9x2 items=14 total=EUR_2847.50 warehouse=Frankfurt retry_count=2 queue_depth=847"
+      - --telemetry-attributes=service.name="order-processor",service.version="1.8.0",deployment.environment="production",host.name="worker-7c4b2-p9x1",cloud.region="eu-west-4",cloud.provider="gcp"
+      - --otlp-attributes=order.id="ord_9f2x8k",customer.id="cust_m3k9x2",queue.name="orders-high-priority",processing.stage="validation",db.system="postgresql"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  log-gen-auth:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: log-gen-auth
+    command:
+      - logs
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=2
+      - --rate=2000
+      - --duration=60s
+      - --severity-text=ERROR
+      - --body="[auth-service] Authentication failed for user usr_x9k2m token_type=bearer error=token_expired issuer=https://auth.example.com/oauth2 client_ip=198.51.100.42 user_agent=Mozilla/5.0"
+      - --telemetry-attributes=service.name="auth-service",service.version="3.2.1",deployment.environment="production",host.name="auth-8f7d3-m2x9",cloud.region="eu-west-4",cloud.provider="gcp"
+      - --otlp-attributes=auth.method="oauth2",auth.error="token_expired",net.peer.ip="198.51.100.42",http.user_agent="Mozilla/5.0 (X11; Linux x86_64)",enduser.scope="openid profile email"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  # --- TRACE GENERATORS ---
+
+  trace-gen-api:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: trace-gen-api
+    command:
+      - traces
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=3
+      - --rate=2000
+      - --duration=60s
+      - --span-duration=150ms
+      - --status-code=Ok
+      - --telemetry-attributes=service.name="api-gateway",service.version="2.14.3",deployment.environment="production",host.name="api-gw-5d8f9-xk2m4",cloud.region="eu-west-1"
+      - --otlp-attributes=http.method="GET",http.route="/api/v2/users/:id",http.status_code="200",db.system="postgresql",db.statement="SELECT * FROM users WHERE id = $1",net.peer.name="db-primary.internal"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  trace-gen-worker:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: trace-gen-worker
+    command:
+      - traces
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=3
+      - --rate=2000
+      - --duration=60s
+      - --span-duration=500ms
+      - --status-code=Error
+      - --telemetry-attributes=service.name="payment-service",service.version="4.1.0",deployment.environment="production",host.name="pay-2c9f1-k8x3",cloud.region="eu-west-4"
+      - --otlp-attributes=rpc.system="grpc",rpc.service="PaymentService",rpc.method="ProcessPayment",payment.provider="stripe",payment.currency="EUR",net.peer.name="stripe-api.internal"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  # --- METRIC GENERATORS ---
+
+  metric-gen:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: metric-gen
+    command:
+      - metrics
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=5
+      - --rate=5000
+      - --duration=60s
+      - --metric-type=Sum
+      - --telemetry-attributes=service.name="infra-monitor",service.version="1.0.0",deployment.environment="production",host.name="monitor-4a8c2-j7x9",cloud.region="eu-west-4"
+      - --otlp-attributes=container.name="api-gateway",k8s.pod.name="api-gw-5d8f9-xk2m4",k8s.namespace.name="production",k8s.node.name="gke-prod-pool-1-abc123"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+networks:
+  repro-net:
+    driver: bridge

--- a/repro-batch-400/docker-compose-large-batch.yml
+++ b/repro-batch-400/docker-compose-large-batch.yml
@@ -1,0 +1,36 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.131.0
+    container_name: otel-collector-large-batch
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config-large-batch.yaml:/etc/otel-collector-config.yaml:ro
+    environment:
+      - OLLY_GARDEN_API_KEY=${OLLY_GARDEN_API_KEY}
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+    networks:
+      - repro-net
+
+  log-generator:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: log-generator-large-batch
+    command:
+      - logs
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=10
+      - --rate=5000
+      - --duration=120s
+      - --otlp-attributes=service.namespace="e2e-batch-test"
+      - --severity-text=INFO
+      - --body="Batch size reproduction test log entry with some payload to increase message size for testing purposes"
+    depends_on:
+      - otel-collector
+    networks:
+      - repro-net
+
+networks:
+  repro-net:
+    driver: bridge

--- a/repro-batch-400/docker-compose-small-batch-sizer.yml
+++ b/repro-batch-400/docker-compose-small-batch-sizer.yml
@@ -1,0 +1,133 @@
+services:
+  payload-sizer:
+    image: python:3.12-slim
+    container_name: payload-sizer-small
+    volumes:
+      - ./payload-sizer.py:/app/payload-sizer.py:ro
+    command: ["sh", "-c", "pip install --quiet cramjam && python3 /app/payload-sizer.py"]
+    networks:
+      - repro-net
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.131.0
+    container_name: otel-collector-small-batch-sizer
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config-small-batch-sizer.yaml:/etc/otel-collector-config.yaml:ro
+    ports:
+      - "4317:4317"
+    depends_on:
+      - payload-sizer
+    networks:
+      - repro-net
+
+  # --- LOG GENERATORS (same realistic setup, same rate) ---
+
+  log-gen-api:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: log-gen-api-small
+    command:
+      - logs
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=3
+      - --rate=3000
+      - --duration=60s
+      - --severity-text=INFO
+      - --body="[api-gateway] POST /api/v2/orders request_id=a]bf9c2e1 user_id=usr_8x7k2m status=200 latency_ms=142 region=eu-west-1 pod=api-gw-5d8f9-xk2m4"
+      - --telemetry-attributes=service.name="api-gateway",service.version="2.14.3",deployment.environment="production",host.name="api-gw-5d8f9-xk2m4",cloud.region="eu-west-1",cloud.provider="gcp"
+      - --otlp-attributes=http.method="POST",http.route="/api/v2/orders",http.status_code="200",user.tier="enterprise",request.size_bytes="4521",response.size_bytes="892"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  log-gen-worker:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: log-gen-worker-small
+    command:
+      - logs
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=3
+      - --rate=3000
+      - --duration=60s
+      - --severity-text=WARN
+      - --body="[order-processor] Processing order ord_9f2x8k for customer cust_m3k9x2 items=14 total=EUR_2847.50 warehouse=Frankfurt retry_count=2 queue_depth=847"
+      - --telemetry-attributes=service.name="order-processor",service.version="1.8.0",deployment.environment="production",host.name="worker-7c4b2-p9x1",cloud.region="eu-west-4",cloud.provider="gcp"
+      - --otlp-attributes=order.id="ord_9f2x8k",customer.id="cust_m3k9x2",queue.name="orders-high-priority",processing.stage="validation",db.system="postgresql"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  log-gen-auth:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: log-gen-auth-small
+    command:
+      - logs
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=2
+      - --rate=2000
+      - --duration=60s
+      - --severity-text=ERROR
+      - --body="[auth-service] Authentication failed for user usr_x9k2m token_type=bearer error=token_expired issuer=https://auth.example.com/oauth2 client_ip=198.51.100.42 user_agent=Mozilla/5.0"
+      - --telemetry-attributes=service.name="auth-service",service.version="3.2.1",deployment.environment="production",host.name="auth-8f7d3-m2x9",cloud.region="eu-west-4",cloud.provider="gcp"
+      - --otlp-attributes=auth.method="oauth2",auth.error="token_expired",net.peer.ip="198.51.100.42",http.user_agent="Mozilla/5.0 (X11; Linux x86_64)",enduser.scope="openid profile email"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  # --- TRACE GENERATORS ---
+
+  trace-gen-api:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: trace-gen-api-small
+    command:
+      - traces
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=3
+      - --rate=2000
+      - --duration=60s
+      - --span-duration=150ms
+      - --status-code=Ok
+      - --telemetry-attributes=service.name="api-gateway",service.version="2.14.3",deployment.environment="production",host.name="api-gw-5d8f9-xk2m4",cloud.region="eu-west-1"
+      - --otlp-attributes=http.method="GET",http.route="/api/v2/users/:id",http.status_code="200",db.system="postgresql",db.statement="SELECT * FROM users WHERE id = $1",net.peer.name="db-primary.internal"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  trace-gen-worker:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: trace-gen-worker-small
+    command:
+      - traces
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=3
+      - --rate=2000
+      - --duration=60s
+      - --span-duration=500ms
+      - --status-code=Error
+      - --telemetry-attributes=service.name="payment-service",service.version="4.1.0",deployment.environment="production",host.name="pay-2c9f1-k8x3",cloud.region="eu-west-4"
+      - --otlp-attributes=rpc.system="grpc",rpc.service="PaymentService",rpc.method="ProcessPayment",payment.provider="stripe",payment.currency="EUR",net.peer.name="stripe-api.internal"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+  # --- METRIC GENERATORS ---
+
+  metric-gen:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: metric-gen-small
+    command:
+      - metrics
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=5
+      - --rate=5000
+      - --duration=60s
+      - --metric-type=Sum
+      - --telemetry-attributes=service.name="infra-monitor",service.version="1.0.0",deployment.environment="production",host.name="monitor-4a8c2-j7x9",cloud.region="eu-west-4"
+      - --otlp-attributes=container.name="api-gateway",k8s.pod.name="api-gw-5d8f9-xk2m4",k8s.namespace.name="production",k8s.node.name="gke-prod-pool-1-abc123"
+    depends_on: [otel-collector]
+    networks: [repro-net]
+
+networks:
+  repro-net:
+    driver: bridge

--- a/repro-batch-400/docker-compose-small-batch.yml
+++ b/repro-batch-400/docker-compose-small-batch.yml
@@ -1,0 +1,36 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.131.0
+    container_name: otel-collector-small-batch
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config-small-batch.yaml:/etc/otel-collector-config.yaml:ro
+    environment:
+      - OLLY_GARDEN_API_KEY=${OLLY_GARDEN_API_KEY}
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+    networks:
+      - repro-net
+
+  log-generator:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.131.0
+    container_name: log-generator-small-batch
+    command:
+      - logs
+      - --otlp-endpoint=otel-collector:4317
+      - --otlp-insecure
+      - --workers=10
+      - --rate=5000
+      - --duration=120s
+      - --otlp-attributes=service.namespace="e2e-batch-test"
+      - --severity-text=INFO
+      - --body="Batch size reproduction test log entry with some payload to increase message size for testing purposes"
+    depends_on:
+      - otel-collector
+    networks:
+      - repro-net
+
+networks:
+  repro-net:
+    driver: bridge

--- a/repro-batch-400/otel-collector-config-go-bench.yaml
+++ b/repro-batch-400/otel-collector-config-go-bench.yaml
@@ -1,0 +1,52 @@
+# Exports to Go compression-bench with no compression on the wire.
+# The Go server receives raw protobuf and benchmarks all compression formats itself.
+# This gives accurate Go-native compression/decompression timings.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        include_metadata: true
+      http:
+        endpoint: 0.0.0.0:4318
+        include_metadata: true
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 80
+    spike_limit_percentage: 20
+
+  batch/large:
+    send_batch_size: 100000
+    send_batch_max_size: 100000
+    timeout: 15s
+
+exporters:
+  otlphttp/bench:
+    endpoint: http://compression-bench:4318
+    compression: none
+
+  debug:
+    verbosity: basic
+
+service:
+  extensions: []
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch/large]
+      exporters: [otlphttp/bench, debug]
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch/large]
+      exporters: [otlphttp/bench, debug]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch/large]
+      exporters: [otlphttp/bench, debug]
+
+  telemetry:
+    logs:
+      level: info

--- a/repro-batch-400/otel-collector-config-large-batch-sizer.yaml
+++ b/repro-batch-400/otel-collector-config-large-batch-sizer.yaml
@@ -1,0 +1,63 @@
+# Large batch — exports to local payload-sizer with all compression formats.
+# Tests all signal types: logs, traces, and metrics.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        include_metadata: true
+      http:
+        endpoint: 0.0.0.0:4318
+        include_metadata: true
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 80
+    spike_limit_percentage: 20
+
+  batch/large:
+    send_batch_size: 100000
+    send_batch_max_size: 100000
+    timeout: 15s
+
+exporters:
+  otlphttp/gzip:
+    endpoint: http://payload-sizer:4318
+    compression: gzip
+
+  otlphttp/none:
+    endpoint: http://payload-sizer:4319
+    compression: none
+
+  otlphttp/snappy:
+    endpoint: http://payload-sizer:4320
+    compression: snappy
+
+  otlphttp/zstd:
+    endpoint: http://payload-sizer:4321
+    compression: zstd
+
+  debug:
+    verbosity: basic
+
+service:
+  extensions: []
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch/large]
+      exporters: [otlphttp/gzip, otlphttp/none, otlphttp/snappy, otlphttp/zstd, debug]
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch/large]
+      exporters: [otlphttp/gzip, otlphttp/none, otlphttp/snappy, otlphttp/zstd, debug]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch/large]
+      exporters: [otlphttp/gzip, otlphttp/none, otlphttp/snappy, otlphttp/zstd, debug]
+
+  telemetry:
+    logs:
+      level: info

--- a/repro-batch-400/otel-collector-config-large-batch.yaml
+++ b/repro-batch-400/otel-collector-config-large-batch.yaml
@@ -1,0 +1,68 @@
+# Reproduces partner config with 100K batch size that causes 400 errors.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        include_metadata: true
+        keepalive:
+          server_parameters:
+            max_connection_idle: 5s
+      http:
+        endpoint: 0.0.0.0:4318
+        include_metadata: true
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 80
+    spike_limit_percentage: 20
+
+  batch/logs_process:
+    metadata_keys:
+      - X-Scope-OrgID
+    send_batch_size: 10000
+    send_batch_max_size: 10000
+    timeout: 1s
+
+  attributes:
+    actions:
+      - action: upsert
+        from_context: X-Scope-OrgID
+        key: X-Scope-OrgID
+
+  batch/logs_export:
+    metadata_keys:
+      - X-Scope-OrgID
+    send_batch_size: 100000
+    send_batch_max_size: 100000
+    timeout: 10s
+
+exporters:
+  otlphttp/ollygarden:
+    endpoint: https://in.ollygarden.cloud
+    headers:
+      Authorization: "Bearer ${env:OLLY_GARDEN_API_KEY}"
+
+  debug:
+    verbosity: basic
+
+service:
+  extensions: []
+  pipelines:
+    logs:
+      receivers:
+        - otlp
+      processors:
+        - memory_limiter
+        - batch/logs_process
+        - attributes
+        - batch/logs_export
+      exporters:
+        - otlphttp/ollygarden
+        - debug
+
+  telemetry:
+    logs:
+      level: info

--- a/repro-batch-400/otel-collector-config-small-batch-sizer.yaml
+++ b/repro-batch-400/otel-collector-config-small-batch-sizer.yaml
@@ -1,0 +1,63 @@
+# Small batch (5K) — exports to local payload-sizer with all compression formats.
+# Tests all signal types: logs, traces, and metrics.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        include_metadata: true
+      http:
+        endpoint: 0.0.0.0:4318
+        include_metadata: true
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 80
+    spike_limit_percentage: 20
+
+  batch/small:
+    send_batch_size: 5000
+    send_batch_max_size: 5000
+    timeout: 5s
+
+exporters:
+  otlphttp/gzip:
+    endpoint: http://payload-sizer:4318
+    compression: gzip
+
+  otlphttp/none:
+    endpoint: http://payload-sizer:4319
+    compression: none
+
+  otlphttp/snappy:
+    endpoint: http://payload-sizer:4320
+    compression: snappy
+
+  otlphttp/zstd:
+    endpoint: http://payload-sizer:4321
+    compression: zstd
+
+  debug:
+    verbosity: basic
+
+service:
+  extensions: []
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch/small]
+      exporters: [otlphttp/gzip, otlphttp/none, otlphttp/snappy, otlphttp/zstd, debug]
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch/small]
+      exporters: [otlphttp/gzip, otlphttp/none, otlphttp/snappy, otlphttp/zstd, debug]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch/small]
+      exporters: [otlphttp/gzip, otlphttp/none, otlphttp/snappy, otlphttp/zstd, debug]
+
+  telemetry:
+    logs:
+      level: info

--- a/repro-batch-400/otel-collector-config-small-batch.yaml
+++ b/repro-batch-400/otel-collector-config-small-batch.yaml
@@ -1,0 +1,59 @@
+# Same as partner config but with reduced batch size to verify the fix.
+# Use this to confirm that smaller batches resolve the 400 errors.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        include_metadata: true
+        keepalive:
+          server_parameters:
+            max_connection_idle: 5s
+      http:
+        endpoint: 0.0.0.0:4318
+        include_metadata: true
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 80
+    spike_limit_percentage: 20
+
+  batch/logs:
+    send_batch_size: 5000
+    send_batch_max_size: 5000
+    timeout: 5s
+
+exporters:
+  otlphttp/ollygarden:
+    endpoint: https://in.ollygarden.cloud
+    headers:
+      Authorization: "Bearer ${env:OLLY_GARDEN_API_KEY}"
+
+  debug:
+    verbosity: basic
+
+service:
+  extensions: []
+  pipelines:
+    logs:
+      receivers:
+        - otlp
+      processors:
+        - memory_limiter
+        - batch/logs
+      exporters:
+        - otlphttp/ollygarden
+        - debug
+
+  telemetry:
+    logs:
+      level: info
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888

--- a/repro-batch-400/payload-sizer.py
+++ b/repro-batch-400/payload-sizer.py
@@ -1,0 +1,98 @@
+"""Minimal OTLP HTTP receiver that logs request payload sizes and decompression time.
+
+Listens on four ports, one per compression format:
+  - :4318 — gzip
+  - :4319 — none (uncompressed)
+  - :4320 — snappy
+  - :4321 — zstd
+
+Reports wire size, decompressed size, compression ratio, and decompression time.
+"""
+
+import gzip
+import threading
+import time
+import zlib
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+snappy_decode = None
+zstd_decompress = None
+
+try:
+    import cramjam
+    snappy_decode = lambda data: bytes(cramjam.snappy.decompress_raw(data))
+    zstd_decompress = lambda data: bytes(cramjam.zstd.decompress(data))
+except ImportError:
+    pass
+
+PORT_LABELS = {
+    4318: "gzip",
+    4319: "none",
+    4320: "snappy",
+    4321: "zstd",
+}
+
+
+class PayloadSizerHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(length)
+        encoding = self.headers.get("Content-Encoding", "none")
+        port = self.server.server_address[1]
+        label = PORT_LABELS.get(port, str(port))
+
+        # Extract signal type from path (/v1/logs, /v1/traces, /v1/metrics)
+        signal = self.path.rsplit("/", 1)[-1] if "/" in self.path else "unknown"
+
+        decompressed_size = length
+        decompress_us = 0
+
+        if encoding == "gzip":
+            t0 = time.monotonic()
+            decompressed_size = len(gzip.decompress(body))
+            decompress_us = (time.monotonic() - t0) * 1_000_000
+        elif encoding == "zlib":
+            t0 = time.monotonic()
+            decompressed_size = len(zlib.decompress(body))
+            decompress_us = (time.monotonic() - t0) * 1_000_000
+        elif encoding == "snappy" and snappy_decode:
+            t0 = time.monotonic()
+            decompressed_size = len(snappy_decode(body))
+            decompress_us = (time.monotonic() - t0) * 1_000_000
+        elif encoding == "zstd" and zstd_decompress:
+            t0 = time.monotonic()
+            decompressed_size = len(zstd_decompress(body))
+            decompress_us = (time.monotonic() - t0) * 1_000_000
+
+        ratio = f"{decompressed_size / length:.1f}x" if length > 0 else "N/A"
+
+        decompress_str = f"{decompress_us:.0f}us" if decompress_us > 0 else "N/A"
+
+        print(
+            f"[{label:>6}] [{signal:>7}] "
+            f"wire: {length:>12,} bytes ({length / 1024 / 1024:>6.2f} MB) | "
+            f"decompressed: {decompressed_size:>12,} bytes ({decompressed_size / 1024 / 1024:>6.2f} MB) | "
+            f"ratio: {ratio:>6} | "
+            f"decompress: {decompress_str}",
+            flush=True,
+        )
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+    def log_message(self, format, *args):
+        pass
+
+
+def run_server(port):
+    server = HTTPServer(("0.0.0.0", port), PayloadSizerHandler)
+    print(f"Payload sizer listening on :{port} ({PORT_LABELS.get(port, '?')})", flush=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    for port in [4318, 4319, 4320]:
+        threading.Thread(target=run_server, args=(port,), daemon=True).start()
+    run_server(4321)


### PR DESCRIPTION
This pull request introduces a reproducible setup for testing OpenTelemetry Collector batch size effects on HTTP export errors, specifically targeting a scenario where large batches (100,000 log records) cause HTTP 400 errors. The setup includes documentation, Docker Compose files, and collector configs for both problematic (large batch) and working (small batch) cases. The main goal is to help diagnose and verify the impact of batch sizing on log export reliability.